### PR TITLE
Phase 1: Route Grafana through CloudFront at /grafana

### DIFF
--- a/infra/stacks/backend_stack.py
+++ b/infra/stacks/backend_stack.py
@@ -228,6 +228,8 @@ class BackendStack(Stack):
             '      - "3000:3000"',
             "    environment:",
             "      - GF_SECURITY_ADMIN_PASSWORD=sentinel",
+            "      - GF_SERVER_ROOT_URL=https://%(domain)s/grafana/",
+            "      - GF_SERVER_SERVE_FROM_SUB_PATH=true",
             "    volumes:",
             "      - grafana_data:/var/lib/grafana",
             "",
@@ -336,7 +338,7 @@ class BackendStack(Stack):
             ]
         )
 
-        alb = elbv2.ApplicationLoadBalancer(
+        self.alb = elbv2.ApplicationLoadBalancer(
             self, "ALB",
             vpc=vpc,
             internet_facing=True,
@@ -345,10 +347,10 @@ class BackendStack(Stack):
         )
 
         # Allow ALB to reach EC2
-        self.sg.connections.allow_from(alb, ec2.Port.tcp(9000))
+        self.sg.connections.allow_from(self.alb, ec2.Port.tcp(9000))
 
         # TheHive listener (HTTP port 80 -> port 9000 on EC2)
-        listener = alb.add_listener("HttpListener", port=80)
+        listener = self.alb.add_listener("HttpListener", port=80)
         listener.add_targets(
             "TheHiveTarget",
             port=9000,
@@ -364,7 +366,7 @@ class BackendStack(Stack):
         )
 
         # Grafana listener (HTTP port 3000 -> port 3000 on EC2)
-        grafana_listener = alb.add_listener(
+        grafana_listener = self.alb.add_listener(
             "GrafanaListener", 
             port=3000,
             protocol=elbv2.ApplicationProtocol.HTTP
@@ -435,7 +437,7 @@ class BackendStack(Stack):
 
         # ── Outputs ───────────────────────────────────────────────────────────
         CfnOutput(self, "InstanceId", value=self.instance.instance_id)
-        CfnOutput(self, "ALBEndpoint", value=alb.load_balancer_dns_name,
+        CfnOutput(self, "ALBEndpoint", value=self.alb.load_balancer_dns_name,
                   export_name="SentinelNetALBEndpoint")
         CfnOutput(self, "AlertsBucketName",
                   value=self.alerts_bucket.bucket_name)

--- a/infra/stacks/website_stack.py
+++ b/infra/stacks/website_stack.py
@@ -14,7 +14,7 @@ from aws_cdk import CfnOutput, RemovalPolicy, Stack, Tags
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_s3_deployment as s3_deploy
 from aws_cdk import aws_cloudfront as cloudfront
-from aws_cdk.aws_cloudfront_origins import S3BucketOrigin
+from aws_cdk.aws_cloudfront_origins import S3BucketOrigin, HttpOrigin
 from aws_cdk import aws_cognito as cognito
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_apigatewayv2 as apigwv2
@@ -82,6 +82,28 @@ class WebsiteStack(Stack):
                 ],
             ),
             default_root_object="index.html",
+        )
+
+        grafana_origin = HttpOrigin(
+            backend_stack.alb.load_balancer_dns_name,
+            http_port=3000,
+            protocol_policy=cloudfront.OriginProtocolPolicy.HTTP_ONLY
+        )
+
+        self.distribution.add_behavior(
+            "/grafana",
+            origin=grafana_origin,
+            viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
+            origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER
+        )
+
+        self.distribution.add_behavior(
+            "/grafana/*",
+            origin=grafana_origin,
+            viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
+            origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER
         )
 
         website_url = f"https://{self.distribution.distribution_domain_name}"


### PR DESCRIPTION
This adds basic routing so Grafana can be accessed through our existing CloudFront URL at /grafana.

Right now this does not add authentication or restrict access. The goal is just to get the routing working end-to-end before adding security.

What this change does:

Exposes the backend ALB so the website stack can route to it
Configures Grafana to work under a subpath (/grafana)
Adds CloudFront behaviors to forward /grafana traffic to the ALB

I tested this locally by running cdk synth to make sure the stack builds correctly.

Next step:
Once this is working, the next step is to add authentication (Cognito) so users must log in before accessing Grafana.