### PR TITLE
Added a admin terminal to the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,39 @@ When the Website deploy finishes, the output shows **WebsiteURL** (e.g. `https:/
 - **“Cannot delete export … in use by SentinelNet-Backend”** (when deploying Network) → Run the one-time fix: from `infra/`, run `./fix-network-export-conflict.sh`. Then deploy as usual.
 
 More detail: **infra/HOW-TO-DEPLOY.md**.
+
+---
+
+## Access Management Terminal
+
+SentinelNet now includes an admin-only **Access Management Terminal** at `/admin/access`.
+
+- It is a terminal-style UI, but it is **not** a real shell and does **not** execute OS commands.
+- It translates a small approved command set into structured API requests backed by Cognito admin APIs.
+- Cognito groups remain the source of truth for access:
+  - `SentinelNetAdmins`
+  - `SentinelNetAnalysts`
+  - `SentinelNetViewers`
+- Only users in `SentinelNetAdmins` can access the page or call the admin access API.
+
+Supported commands:
+
+- `help`
+- `list-users`
+- `get-user <email-or-username>`
+- `grant-access <email-or-username> <Admins|Analysts|Viewers>`
+- `revoke-access <email-or-username> <Admins|Analysts|Viewers>`
+- `list-groups`
+- `whoami`
+- `clear`
+
+New Lambda environment variables:
+
+- `USER_POOL_ID`
+- `ADMIN_GROUP_NAME`
+- `ANALYST_GROUP_NAME`
+- `VIEWER_GROUP_NAME`
+
+Deployment note:
+
+- Redeploy `SentinelNet-Website` after building the frontend so CloudFront gets the new page, runtime config, and the new admin access HTTP API.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,6 +16,7 @@ React + Vite app. Dark theme. Marketing pages (Home, Product, Pricing, About) pl
 | **`src/components/`** | Reusable UI: **TopNav** (logo + nav + Console dropdown + Account dropdown), **Footer**, **PublicLayout** (TopNav + page content + Footer), **ProtectedRoute** (redirects to login if not signed in), **DevAdvice** (the “How to build this” boxes on console pages). |
 | **`src/auth/`** | Cognito sign-in: **config.js** (pool ID, client ID, redirect URLs — uses `config.json` when deployed), **resolvedConfig.js** (runtime config from `config.json`), **signOut.js**. |
 | **`src/api/`** | API clients. **profile.js** talks to the profile API (get profile, update profile — display name, avatar icon, job, bio). |
+| **`src/admin/`** | Access Management Terminal parser logic and tests. Keeps the command surface limited to approved admin operations. |
 | **`index.html`** | The one HTML file. Loads `main.jsx`. |
 | **`package.json`** | Dependencies and scripts. **Do not** delete or rename scripts; the deploy process runs `npm run build`. |
 
@@ -38,8 +39,10 @@ There is **no** `Layout.jsx` with a sidebar. The layout is: **TopNav** at the to
 - **`/reports`** — Reports (protected)  
 - **`/settings`** — Settings (protected)  
 - **`/account`** — Account / profile (protected; edit display name, icon, job, bio)
+- **`/admin/access`** — Access Management Terminal (protected; admin-only)
 
 Protected = you must be signed in; otherwise you’re sent to login.
+Admin-only = you must also be in `SentinelNetAdmins`.
 
 ---
 
@@ -83,6 +86,8 @@ npm run dev
 - **Add reusable UI** — Put it in `src/components/` and import it where needed.
 - **Change colors / fonts** — Edit `:root` and other rules in `src/index.css`.
 - **Call a new API** — Add a client in `src/api/` (like `profile.js`) and use it from the page or component that needs it.
+
+The Access Management Terminal intentionally does not pass raw commands to the backend. The frontend parser validates supported commands first, then maps them to explicit REST calls against the admin access API.
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "start": "vite",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "framer-motion": "^12.34.3",
@@ -21,6 +22,7 @@
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,8 @@ import Reports from './pages/Reports'
 import Settings from './pages/Settings'
 import Account from './pages/Account'
 import Login from './pages/Login'
+import AdminAccessTerminal from './pages/AdminAccessTerminal'
+import { ADMIN_GROUP } from './auth/groups'
 
 export default function App() {
   return (
@@ -32,6 +34,7 @@ export default function App() {
         <Route path="reports" element={<ProtectedRoute><Reports /></ProtectedRoute>} />
         <Route path="settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
         <Route path="account" element={<ProtectedRoute><Account /></ProtectedRoute>} />
+        <Route path="admin/access" element={<ProtectedRoute requiredGroups={[ADMIN_GROUP]}><AdminAccessTerminal /></ProtectedRoute>} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/frontend/src/admin/terminalParser.js
+++ b/frontend/src/admin/terminalParser.js
@@ -1,0 +1,75 @@
+import { ADMIN_GROUP, SENTINEL_GROUPS, TERMINAL_GROUP_ALIASES } from '../auth/groups'
+
+function tokenize(input) {
+  if (typeof input !== 'string') return []
+  return input.trim().split(/\s+/).filter(Boolean)
+}
+
+function normalizeGroup(group) {
+  if (typeof group !== 'string') return null
+  const normalized = TERMINAL_GROUP_ALIASES[group.trim().toLowerCase()]
+  return normalized ?? null
+}
+
+function syntaxError(message) {
+  return { ok: false, error: message }
+}
+
+export function parseTerminalCommand(input) {
+  const tokens = tokenize(input)
+  if (!tokens.length) return syntaxError('Enter a command. Type "help" to see supported commands.')
+
+  const [command, ...args] = tokens
+
+  switch (command.toLowerCase()) {
+    case 'help':
+      if (args.length) return syntaxError('help does not take arguments.')
+      return { ok: true, command: 'help' }
+    case 'clear':
+      if (args.length) return syntaxError('clear does not take arguments.')
+      return { ok: true, command: 'clear' }
+    case 'list-users':
+      if (args.length) return syntaxError('list-users does not take arguments.')
+      return { ok: true, command: 'list-users' }
+    case 'list-groups':
+      if (args.length) return syntaxError('list-groups does not take arguments.')
+      return { ok: true, command: 'list-groups' }
+    case 'whoami':
+      if (args.length) return syntaxError('whoami does not take arguments.')
+      return { ok: true, command: 'whoami' }
+    case 'get-user':
+      if (args.length !== 1) return syntaxError('Usage: get-user <email-or-username>')
+      return { ok: true, command: 'get-user', identifier: args[0] }
+    case 'grant-access':
+    case 'revoke-access': {
+      if (args.length !== 2) return syntaxError(`Usage: ${command} <email-or-username> <Admins|Analysts|Viewers>`)
+      const group = normalizeGroup(args[1])
+      if (!group) return syntaxError('Invalid group. Use Admins, Analysts, or Viewers.')
+      return {
+        ok: true,
+        command: command.toLowerCase(),
+        identifier: args[0],
+        group,
+      }
+    }
+    default:
+      return syntaxError(`Unknown command: ${command}. Type "help" to see supported commands.`)
+  }
+}
+
+export function getHelpLines() {
+  return [
+    'Supported commands:',
+    'help',
+    'list-users',
+    'get-user <email-or-username>',
+    'grant-access <email-or-username> <Admins|Analysts|Viewers>',
+    'revoke-access <email-or-username> <Admins|Analysts|Viewers>',
+    'list-groups',
+    'whoami',
+    'clear',
+    '',
+    `Admin group required: ${ADMIN_GROUP}`,
+    `Managed groups: ${SENTINEL_GROUPS.join(', ')}`,
+  ]
+}

--- a/frontend/src/admin/terminalParser.test.js
+++ b/frontend/src/admin/terminalParser.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { getHelpLines, parseTerminalCommand } from './terminalParser'
+
+describe('parseTerminalCommand', () => {
+  it('parses no-arg commands', () => {
+    expect(parseTerminalCommand('help')).toEqual({ ok: true, command: 'help' })
+    expect(parseTerminalCommand('list-users')).toEqual({ ok: true, command: 'list-users' })
+    expect(parseTerminalCommand('whoami')).toEqual({ ok: true, command: 'whoami' })
+    expect(parseTerminalCommand('clear')).toEqual({ ok: true, command: 'clear' })
+  })
+
+  it('parses get-user', () => {
+    expect(parseTerminalCommand('get-user analyst@example.com')).toEqual({
+      ok: true,
+      command: 'get-user',
+      identifier: 'analyst@example.com',
+    })
+  })
+
+  it('normalizes grant and revoke groups', () => {
+    expect(parseTerminalCommand('grant-access user@example.com Admins')).toEqual({
+      ok: true,
+      command: 'grant-access',
+      identifier: 'user@example.com',
+      group: 'SentinelNetAdmins',
+    })
+    expect(parseTerminalCommand('revoke-access bob Analysts')).toEqual({
+      ok: true,
+      command: 'revoke-access',
+      identifier: 'bob',
+      group: 'SentinelNetAnalysts',
+    })
+  })
+
+  it('rejects invalid input', () => {
+    expect(parseTerminalCommand('')).toEqual({
+      ok: false,
+      error: 'Enter a command. Type "help" to see supported commands.',
+    })
+    expect(parseTerminalCommand('grant-access user@example.com Owners')).toEqual({
+      ok: false,
+      error: 'Invalid group. Use Admins, Analysts, or Viewers.',
+    })
+    expect(parseTerminalCommand('rm -rf /')).toEqual({
+      ok: false,
+      error: 'Unknown command: rm. Type "help" to see supported commands.',
+    })
+  })
+})
+
+describe('getHelpLines', () => {
+  it('includes the supported commands', () => {
+    const lines = getHelpLines().join('\n')
+    expect(lines).toContain('list-users')
+    expect(lines).toContain('grant-access <email-or-username> <Admins|Analysts|Viewers>')
+    expect(lines).toContain('SentinelNetAdmins')
+  })
+})

--- a/frontend/src/api/adminAccess.js
+++ b/frontend/src/api/adminAccess.js
@@ -1,0 +1,62 @@
+import { getAdminAccessApiUrl } from '../auth/config'
+
+function getToken(user) {
+  return user?.access_token ?? user?.id_token
+}
+
+async function request(user, path, options = {}) {
+  const baseUrl = getAdminAccessApiUrl()
+  if (!baseUrl) throw new Error('Access management API not configured')
+
+  const token = getToken(user)
+  if (!token) throw new Error('Not signed in')
+
+  const res = await fetch(`${baseUrl}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.headers ?? {}),
+    },
+  })
+
+  const body = await res.json().catch(() => ({}))
+
+  if (!res.ok) {
+    throw new Error(body.error || res.statusText || 'Request failed')
+  }
+
+  return body
+}
+
+export function listGroups(user) {
+  return request(user, '/admin/access/groups')
+}
+
+export function whoAmI(user) {
+  return request(user, '/admin/access/whoami')
+}
+
+export function listUsers(user, nextToken = '') {
+  const query = nextToken ? `?nextToken=${encodeURIComponent(nextToken)}` : ''
+  return request(user, `/admin/access/users${query}`)
+}
+
+export function getUserAccess(user, identifier) {
+  return request(user, `/admin/access/users/${encodeURIComponent(identifier)}`)
+}
+
+export function grantAccess(user, identifier, group) {
+  return request(user, '/admin/access/grant', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ identifier, group }),
+  })
+}
+
+export function revokeAccess(user, identifier, group) {
+  return request(user, '/admin/access/revoke', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ identifier, group }),
+  })
+}

--- a/frontend/src/auth/config.js
+++ b/frontend/src/auth/config.js
@@ -62,6 +62,11 @@ export function getProfileApiUrl() {
   return c?.profileApiUrl ?? ''
 }
 
+export function getAdminAccessApiUrl() {
+  const c = getResolvedConfig()
+  return c?.adminAccessApiUrl ?? ''
+}
+
 export function getOidcConfig() {
   return {
     authority: getAuthority(),

--- a/frontend/src/auth/groups.js
+++ b/frontend/src/auth/groups.js
@@ -1,0 +1,15 @@
+export const ADMIN_GROUP = 'SentinelNetAdmins'
+export const ANALYST_GROUP = 'SentinelNetAnalysts'
+export const VIEWER_GROUP = 'SentinelNetViewers'
+
+export const SENTINEL_GROUPS = [
+  ADMIN_GROUP,
+  ANALYST_GROUP,
+  VIEWER_GROUP,
+]
+
+export const TERMINAL_GROUP_ALIASES = {
+  admins: ADMIN_GROUP,
+  analysts: ANALYST_GROUP,
+  viewers: VIEWER_GROUP,
+}

--- a/frontend/src/components/TopNav.jsx
+++ b/frontend/src/components/TopNav.jsx
@@ -4,6 +4,7 @@ import { useAuth } from 'react-oidc-context'
 import { signOut } from '../auth/signOut'
 import { getProfile } from '../api/profile'
 import { hasAllowedGroup } from '../auth/access'
+import { ADMIN_GROUP } from '../auth/groups'
 
 const ShieldIcon = () => (
   <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -74,6 +75,10 @@ export default function TopNav() {
   const [profileIcon, setProfileIcon] = useState(null)
   const accountRef = useRef(null)
   const canAccessConsole = auth.isAuthenticated && hasAllowedGroup(auth.user)
+  const isAdmin = auth.isAuthenticated && hasAllowedGroup(auth.user, [ADMIN_GROUP])
+  const visibleConsoleLinks = isAdmin
+    ? [...consoleNavLinks, { to: '/admin/access', label: 'Access Terminal' }]
+    : consoleNavLinks
 
   useEffect(() => {
     if (!auth.user || !canAccessConsole) {
@@ -146,7 +151,7 @@ export default function TopNav() {
         ))}
         {!auth.isLoading && auth.isAuthenticated && canAccessConsole && (
           <>
-            {consoleNavLinks.map(({ to, label }) => (
+            {visibleConsoleLinks.map(({ to, label }) => (
               <NavLink
                 key={to}
                 to={to}

--- a/frontend/src/pages/AdminAccessTerminal.jsx
+++ b/frontend/src/pages/AdminAccessTerminal.jsx
@@ -1,0 +1,289 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useAuth } from 'react-oidc-context'
+import { hasAllowedGroup } from '../auth/access'
+import { ADMIN_GROUP, SENTINEL_GROUPS } from '../auth/groups'
+import {
+  getUserAccess,
+  grantAccess,
+  listGroups,
+  listUsers,
+  revokeAccess,
+  whoAmI,
+} from '../api/adminAccess'
+import { getHelpLines, parseTerminalCommand } from '../admin/terminalParser'
+
+function formatGroups(groups) {
+  return Array.isArray(groups) && groups.length ? groups.join(', ') : '(none)'
+}
+
+function formatUserLine(user) {
+  const status = user.enabled ? 'enabled' : 'disabled'
+  return `${user.username} | ${user.email || 'no-email'} | ${status} | groups: ${formatGroups(user.groups)}`
+}
+
+function createEntry(type, lines) {
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    type,
+    lines: Array.isArray(lines) ? lines : [String(lines)],
+  }
+}
+
+export default function AdminAccessTerminal() {
+  const auth = useAuth()
+  const inputRef = useRef(null)
+  const outputRef = useRef(null)
+  const [input, setInput] = useState('')
+  const [history, setHistory] = useState([])
+  const [historyIndex, setHistoryIndex] = useState(-1)
+  const [entries, setEntries] = useState(() => [
+    createEntry('system', [
+      'SentinelNet Access Management Terminal',
+      `Admin group required: ${ADMIN_GROUP}`,
+      'Type "help" to see supported commands.',
+    ]),
+  ])
+  const [running, setRunning] = useState(false)
+
+  const isAdmin = hasAllowedGroup(auth.user, [ADMIN_GROUP])
+  const promptLabel = useMemo(() => {
+    const email = auth.user?.profile?.email ?? auth.user?.profile?.sub ?? 'admin'
+    return `${email}:~$`
+  }, [auth.user])
+
+  useEffect(() => {
+    outputRef.current?.scrollTo({ top: outputRef.current.scrollHeight, behavior: 'smooth' })
+  }, [entries, running])
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  async function runStructuredCommand(parsed) {
+    switch (parsed.command) {
+      case 'help':
+        return createEntry('output', getHelpLines())
+      case 'list-groups': {
+        const data = await listGroups(auth.user)
+        return createEntry('output', [
+          'Managed groups:',
+          ...data.groups.map((group) => `- ${group}`),
+        ])
+      }
+      case 'whoami': {
+        const data = await whoAmI(auth.user)
+        return createEntry('output', [
+          `User: ${data.user.username}`,
+          `Email: ${data.user.email || 'unknown'}`,
+          `Groups: ${formatGroups(data.user.groups)}`,
+          `Admin: ${data.user.isAdmin ? 'yes' : 'no'}`,
+        ])
+      }
+      case 'list-users': {
+        const data = await listUsers(auth.user)
+        const lines = [
+          `Users returned: ${data.users.length}`,
+          ...data.users.map(formatUserLine),
+        ]
+        if (data.nextToken) {
+          lines.push(`More results available. Next token: ${data.nextToken}`)
+        }
+        return createEntry('output', lines)
+      }
+      case 'get-user': {
+        const data = await getUserAccess(auth.user, parsed.identifier)
+        return createEntry('output', [
+          `User: ${data.user.username}`,
+          `Email: ${data.user.email || 'unknown'}`,
+          `Status: ${data.user.enabled ? 'enabled' : 'disabled'}`,
+          `Groups: ${formatGroups(data.user.groups)}`,
+          `Created: ${data.user.userCreateDate || 'unknown'}`,
+          `Updated: ${data.user.userLastModifiedDate || 'unknown'}`,
+        ])
+      }
+      case 'grant-access': {
+        const data = await grantAccess(auth.user, parsed.identifier, parsed.group)
+        return createEntry('success', [
+          `${data.message}`,
+          `User: ${data.user.username}`,
+          `Groups: ${formatGroups(data.user.groups)}`,
+        ])
+      }
+      case 'revoke-access': {
+        const data = await revokeAccess(auth.user, parsed.identifier, parsed.group)
+        return createEntry('success', [
+          `${data.message}`,
+          `User: ${data.user.username}`,
+          `Groups: ${formatGroups(data.user.groups)}`,
+        ])
+      }
+      default:
+        return createEntry('error', 'Unsupported command.')
+    }
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    if (running) return
+
+    const raw = input.trim()
+    if (!raw) return
+
+    const parsed = parseTerminalCommand(raw)
+    setEntries((current) => [...current, createEntry('command', `${promptLabel} ${raw}`)])
+    setHistory((current) => [...current, raw])
+    setHistoryIndex(-1)
+    setInput('')
+
+    if (!parsed.ok) {
+      setEntries((current) => [...current, createEntry('error', parsed.error)])
+      return
+    }
+
+    if (parsed.command === 'clear') {
+      setEntries([])
+      return
+    }
+
+    setRunning(true)
+    try {
+      const result = await runStructuredCommand(parsed)
+      setEntries((current) => [...current, result])
+    } catch (error) {
+      setEntries((current) => [...current, createEntry('error', error.message || 'Command failed')])
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  function handleHistory(event) {
+    if (!history.length) return
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      const nextIndex = historyIndex < 0 ? history.length - 1 : Math.max(historyIndex - 1, 0)
+      setHistoryIndex(nextIndex)
+      setInput(history[nextIndex])
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      if (historyIndex < 0) return
+      const nextIndex = historyIndex + 1
+      if (nextIndex >= history.length) {
+        setHistoryIndex(-1)
+        setInput('')
+        return
+      }
+      setHistoryIndex(nextIndex)
+      setInput(history[nextIndex])
+    }
+  }
+
+  return (
+    <div className="page-wrap">
+      <div className="page">
+        <div style={{ marginBottom: '1.5rem' }}>
+          <h1>Access Management Terminal</h1>
+          <p style={{ margin: 0, fontSize: '0.9rem', color: 'var(--text-muted)' }}>
+            Admin-only access management on top of the existing Cognito group model.
+          </p>
+        </div>
+
+        <div className="panel" style={{ minHeight: 620 }}>
+          <div className="panel-header">
+            <span>Admin Console</span>
+            <span style={{ color: isAdmin ? 'var(--success)' : 'var(--danger)' }}>
+              {isAdmin ? 'Admin verified' : 'Access denied'}
+            </span>
+          </div>
+          <div
+            ref={outputRef}
+            style={{
+              flex: 1,
+              overflowY: 'auto',
+              padding: '1rem',
+              background: 'linear-gradient(180deg, rgba(8,8,10,0.98), rgba(13,13,16,0.98))',
+              fontFamily: 'var(--font-mono)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '0.85rem',
+            }}
+          >
+            {entries.map((entry) => (
+              <div key={entry.id}>
+                {entry.lines.map((line, index) => (
+                  <div
+                    key={`${entry.id}-${index}`}
+                    style={{
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      color:
+                        entry.type === 'error'
+                          ? 'var(--danger)'
+                          : entry.type === 'success'
+                            ? 'var(--success)'
+                            : entry.type === 'command'
+                              ? 'var(--text-bright)'
+                              : 'var(--text-muted)',
+                      fontSize: '0.8rem',
+                      lineHeight: 1.65,
+                    }}
+                  >
+                    {line}
+                  </div>
+                ))}
+              </div>
+            ))}
+            {running && (
+              <div style={{ color: 'var(--warning)', fontSize: '0.8rem' }}>
+                Executing structured access-management command...
+              </div>
+            )}
+          </div>
+
+          <form
+            onSubmit={handleSubmit}
+            style={{
+              borderTop: '1px solid var(--border)',
+              background: 'var(--bg-card)',
+              padding: '0.9rem 1rem',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.75rem',
+            }}
+          >
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.75rem', color: 'var(--accent)', whiteSpace: 'nowrap' }}>
+              {promptLabel}
+            </span>
+            <input
+              ref={inputRef}
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={handleHistory}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              placeholder='Try "help" or "list-users"'
+              disabled={!isAdmin || running}
+              style={{
+                flex: 1,
+                background: 'transparent',
+                border: 'none',
+                outline: 'none',
+                color: isAdmin ? 'var(--text)' : 'var(--text-dim)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.82rem',
+              }}
+            />
+            <button type="submit" className="btn-primary" disabled={!isAdmin || running}>
+              Run
+            </button>
+          </form>
+
+          <div style={{ padding: '0.9rem 1rem', borderTop: '1px solid var(--border)', color: 'var(--text-dim)', fontSize: '0.78rem' }}>
+            Allowed groups: {SENTINEL_GROUPS.join(', ')}. This interface only issues structured API calls and never executes arbitrary shell commands.
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/README.md
+++ b/frontend/src/pages/README.md
@@ -13,6 +13,7 @@ Each file here is a **page** — a top-level screen that appears when the user h
 | **`Data.jsx`** | `/data` | Security data ingestion, logs, pipeline status. Add data sources and log viewers. |
 | **`Settings.jsx`** | `/settings` | Platform and account configuration. Add forms and preferences. |
 | **`Login.jsx`** | `/login` | Sign-in (no sidebar). Add auth (e.g. OAuth / SSO) when ready. |
+| **`AdminAccessTerminal.jsx`** | `/admin/access` | Admin-only terminal-style UI for Cognito group access management through safe structured API calls. |
 
 ---
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -12,7 +12,7 @@ This folder is the **AWS deployment** for SentinelNet. Everything that runs in A
 | **`cdk.json`** | Tells the CDK CLI to run `app.py` when you run `cdk` commands. You usually don’t need to touch this. |
 | **`requirements.txt`** | Python packages needed for CDK. Run `pip install -r requirements.txt` from this directory before your first `cdk` command. |
 | **`stacks/`** | One Python file per stack. This is where you **edit** when you want to add or change AWS resources. |
-| **`lambda/`** | Lambda function code that gets deployed by the Website stack (the profile API). **`profile_api_py/`** = Python handler for GET/PATCH profile. |
+| **`lambda/`** | Lambda function code that gets deployed by the Website stack. **`profile_api_py/`** = profile GET/PATCH. **`admin_access_api_py/`** = admin-only Cognito access management API. |
 | **`HOW-TO-DEPLOY.md`** | Step-by-step deploy instructions (credentials, build frontend, deploy order). Use this when you’re actually deploying. |
 | **`DEPLOY.md`** | Extra deploy notes (e.g. not committing keys, rotating if leaked). |
 
@@ -26,7 +26,7 @@ You run **all** `cdk` commands from **this directory** (`infra/`). Not from the 
 |------------|------|-------------------------|
 | **SentinelNet-Network** | `stacks/network_stack.py` | **VPC** with public, private, and internal subnets. Outputs VPC ID and subnet IDs. Backend uses this VPC. |
 | **SentinelNet-UserData** | `stacks/user_data_stack.py` | **DynamoDB** (profiles) and **S3** bucket. No Lambda here — just storage. |
-| **SentinelNet-Website** | `stacks/website_stack.py` | **Live site**: S3 + CloudFront, **Cognito**, and **profile API** (Lambda + API Gateway) using the UserData table. Writes `config.json` for the frontend. |
+| **SentinelNet-Website** | `stacks/website_stack.py` | **Live site**: S3 + CloudFront, **Cognito**, the **profile API**, and the **admin access API**. Writes `config.json` for the frontend. |
 | **SentinelNet-Backend** | `stacks/backend_stack.py` | **SOC EC2**: t3.medium running Wazuh, TheHive 5, etc. + SQS/Lambda/S3 alert data lake. |
 
 **Dependencies:** Website uses UserData (profile API). Backend uses Network (VPC + private subnets). **Backend does not deploy Network** — you deploy Network first, then Backend.
@@ -63,7 +63,7 @@ Don’t run `cdk deploy` without approval. The main repo README explains the wor
 
 - **VPC / subnets:** Edit `stacks/network_stack.py`.
 - **DynamoDB / S3 for user data:** Edit `stacks/user_data_stack.py`.
-- **Site, CloudFront, Cognito, profile API:** Edit `stacks/website_stack.py`. Profile API Lambda: `lambda/profile_api_py/handler.py`.
+- **Site, CloudFront, Cognito, profile API, admin access API:** Edit `stacks/website_stack.py`. Profile Lambda: `lambda/profile_api_py/handler.py`. Admin access Lambda: `lambda/admin_access_api_py/handler.py`.
 - **SOC EC2 (Backend):** Edit `stacks/backend_stack.py`. Contains Docker settings and alert pipeline.
 - **New stack:** Add a new file in `stacks/`, extend `Stack`, then in `app.py` instantiate it (e.g. `SomethingStack(app, "SentinelNet-Something", env=env)`).
 

--- a/infra/lambda/admin_access_api_py/handler.py
+++ b/infra/lambda/admin_access_api_py/handler.py
@@ -1,0 +1,260 @@
+import json
+import os
+from datetime import datetime, timezone
+from urllib.parse import unquote
+
+import boto3
+from botocore.exceptions import ClientError
+
+USER_POOL_ID = os.environ["USER_POOL_ID"]
+ADMIN_GROUP_NAME = os.environ.get("ADMIN_GROUP_NAME", "SentinelNetAdmins")
+ANALYST_GROUP_NAME = os.environ.get("ANALYST_GROUP_NAME", "SentinelNetAnalysts")
+VIEWER_GROUP_NAME = os.environ.get("VIEWER_GROUP_NAME", "SentinelNetViewers")
+MANAGED_GROUPS = [ADMIN_GROUP_NAME, ANALYST_GROUP_NAME, VIEWER_GROUP_NAME]
+MANAGED_GROUP_SET = set(MANAGED_GROUPS)
+PAGE_SIZE = int(os.environ.get("LIST_USERS_PAGE_SIZE", "25"))
+
+cognito = boto3.client("cognito-idp")
+
+
+def json_response(body, status_code=200):
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+            "Access-Control-Allow-Headers": "Authorization,Content-Type",
+        },
+        "body": json.dumps(body),
+    }
+
+
+def get_claims(event):
+    return (event or {}).get("requestContext", {}).get("authorizer", {}).get("jwt", {}).get("claims", {})
+
+
+def get_groups_from_claims(claims):
+    raw = claims.get("cognito:groups") or claims.get("groups") or []
+    if isinstance(raw, list):
+        return {str(group).strip() for group in raw if str(group).strip()}
+    if isinstance(raw, str):
+        return {group.strip() for group in raw.replace(" ", ",").split(",") if group.strip()}
+    return set()
+
+
+def get_actor(event):
+    claims = get_claims(event)
+    username = claims.get("cognito:username") or claims.get("username") or claims.get("sub")
+    email = claims.get("email")
+    groups = get_groups_from_claims(claims)
+    return {"username": username, "email": email, "groups": groups}
+
+
+def ensure_admin(event):
+    actor = get_actor(event)
+    if not actor["username"]:
+        return None, json_response({"error": "Unauthorized"}, 401)
+    if ADMIN_GROUP_NAME not in actor["groups"]:
+        return None, json_response({"error": "Forbidden"}, 403)
+    return actor, None
+
+
+def parse_body(event):
+    if not event.get("body"):
+        return {}
+    if isinstance(event["body"], dict):
+        return event["body"]
+    try:
+        return json.loads(event["body"])
+    except Exception:
+        raise ValueError("Invalid JSON")
+
+
+def get_attribute(attributes, name):
+    for attr in attributes or []:
+        if attr.get("Name") == name:
+            return attr.get("Value")
+    return None
+
+
+def serialize_user(user, groups):
+    attributes = user.get("Attributes", [])
+    return {
+        "username": user.get("Username"),
+        "email": get_attribute(attributes, "email"),
+        "enabled": user.get("Enabled", True),
+        "userCreateDate": user.get("UserCreateDate").isoformat() if user.get("UserCreateDate") else None,
+        "userLastModifiedDate": user.get("UserLastModifiedDate").isoformat() if user.get("UserLastModifiedDate") else None,
+        "groups": sorted(group for group in groups if group in MANAGED_GROUP_SET),
+    }
+
+
+def list_groups_for_user(username):
+    response = cognito.admin_list_groups_for_user(
+        UserPoolId=USER_POOL_ID,
+        Username=username,
+    )
+    return sorted(group["GroupName"] for group in response.get("Groups", []) if group.get("GroupName") in MANAGED_GROUP_SET)
+
+
+def find_user(identifier):
+    try:
+        response = cognito.admin_get_user(UserPoolId=USER_POOL_ID, Username=identifier)
+        return {
+            "Username": response.get("Username"),
+            "Enabled": response.get("Enabled", True),
+            "UserCreateDate": response.get("UserCreateDate"),
+            "UserLastModifiedDate": response.get("UserLastModifiedDate"),
+            "Attributes": response.get("UserAttributes", []),
+        }
+    except ClientError as error:
+        code = error.response.get("Error", {}).get("Code")
+        if code != "UserNotFoundException":
+            raise
+
+    paginator = cognito.get_paginator("list_users")
+    for page in paginator.paginate(UserPoolId=USER_POOL_ID, PaginationConfig={"PageSize": 60}):
+        for user in page.get("Users", []):
+            email = get_attribute(user.get("Attributes", []), "email")
+            if email and email.lower() == identifier.lower():
+                return user
+    return None
+
+
+def require_identifier(identifier):
+    if not isinstance(identifier, str) or not identifier.strip():
+        raise ValueError("Missing user identifier")
+    return identifier.strip()
+
+
+def require_group(group):
+    if group not in MANAGED_GROUP_SET:
+        raise ValueError("Invalid group")
+    return group
+
+
+def audit_log(actor, operation, target_user=None, target_group=None, success=True, detail=None):
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "actor": actor["username"],
+        "actorEmail": actor.get("email"),
+        "operation": operation,
+        "targetUser": target_user,
+        "targetGroup": target_group,
+        "success": success,
+        "detail": detail,
+    }
+    print(json.dumps(payload))
+
+
+def handle_list_users(event):
+    # Query params for pagination are intentionally backend-controlled and not
+    # exposed as freeform shell behavior.
+    query = event_query_params(event)
+    next_token = query.get("nextToken")
+    kwargs = {"UserPoolId": USER_POOL_ID, "Limit": PAGE_SIZE}
+    if next_token:
+        kwargs["PaginationToken"] = next_token
+    response = cognito.list_users(**kwargs)
+    users = []
+    for user in response.get("Users", []):
+        groups = list_groups_for_user(user.get("Username"))
+        users.append(serialize_user(user, groups))
+    return json_response({"users": users, "nextToken": response.get("PaginationToken")})
+
+
+def handle_get_user(identifier):
+    user = find_user(identifier)
+    if not user:
+        return json_response({"error": "User not found"}, 404)
+    groups = list_groups_for_user(user["Username"])
+    return json_response({"user": serialize_user(user, groups)})
+
+
+def handle_group_mutation(actor, operation, body):
+    identifier = require_identifier(body.get("identifier"))
+    group = require_group(body.get("group"))
+    user = find_user(identifier)
+    if not user:
+        audit_log(actor, operation, target_user=identifier, target_group=group, success=False, detail="user_not_found")
+        return json_response({"error": "User not found"}, 404)
+
+    username = user["Username"]
+    try:
+        if operation == "grant-access":
+            cognito.admin_add_user_to_group(UserPoolId=USER_POOL_ID, Username=username, GroupName=group)
+            message = f"Granted {group} to {username}"
+        else:
+            cognito.admin_remove_user_from_group(UserPoolId=USER_POOL_ID, Username=username, GroupName=group)
+            message = f"Revoked {group} from {username}"
+        groups = list_groups_for_user(username)
+        audit_log(actor, operation, target_user=username, target_group=group, success=True)
+        return json_response({
+            "ok": True,
+            "message": message,
+            "user": serialize_user(user, groups),
+        })
+    except ClientError as error:
+        audit_log(actor, operation, target_user=username, target_group=group, success=False, detail=error.response.get("Error", {}).get("Code"))
+        print(error)
+        return json_response({"error": "AWS API failure"}, 502)
+
+def event_query_params(event):
+    return (event or {}).get("queryStringParameters") or {}
+
+
+def handler(event, context):
+    event = event or {}
+
+    method = (event.get("requestContext") or {}).get("http", {}).get("method") or event.get("httpMethod")
+    if method == "OPTIONS":
+        return json_response({}, 200)
+
+    actor, auth_error = ensure_admin(event)
+    if auth_error:
+        return auth_error
+
+    path = event.get("rawPath") or (event.get("requestContext") or {}).get("http", {}).get("path", "")
+    try:
+        if method == "GET" and path == "/admin/access/groups":
+            return json_response({"groups": MANAGED_GROUPS})
+
+        if method == "GET" and path == "/admin/access/whoami":
+            return json_response({
+                "user": {
+                    "username": actor["username"],
+                    "email": actor.get("email"),
+                    "groups": sorted(actor["groups"] & MANAGED_GROUP_SET),
+                    "isAdmin": ADMIN_GROUP_NAME in actor["groups"],
+                }
+            })
+
+        if method == "GET" and path == "/admin/access/users":
+            return handle_list_users(event)
+
+        if method == "GET" and path.startswith("/admin/access/users/"):
+            identifier = require_identifier(unquote(path.rsplit("/", 1)[-1]))
+            return handle_get_user(identifier)
+
+        if method == "POST" and path == "/admin/access/grant":
+            return handle_group_mutation(actor, "grant-access", parse_body(event))
+
+        if method == "POST" and path == "/admin/access/revoke":
+            return handle_group_mutation(actor, "revoke-access", parse_body(event))
+
+        return json_response({"error": "Unknown command"}, 404)
+    except ValueError as error:
+        audit_log(actor, "validation-error", success=False, detail=str(error))
+        return json_response({"error": str(error)}, 400)
+    except ClientError as error:
+        audit_log(actor, "aws-error", success=False, detail=error.response.get("Error", {}).get("Code"))
+        print(error)
+        code = error.response.get("Error", {}).get("Code")
+        if code == "UserNotFoundException":
+            return json_response({"error": "User not found"}, 404)
+        return json_response({"error": "AWS API failure"}, 502)
+    except Exception as error:
+        audit_log(actor, "internal-error", success=False, detail=type(error).__name__)
+        print(error)
+        return json_response({"error": "Internal server error"}, 500)

--- a/infra/stacks/website_stack.py
+++ b/infra/stacks/website_stack.py
@@ -17,6 +17,7 @@ from aws_cdk import aws_cloudfront as cloudfront
 from aws_cdk.aws_cloudfront_origins import S3BucketOrigin, HttpOrigin
 from aws_cdk import aws_cognito as cognito
 from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_iam as iam
 from aws_cdk import aws_apigatewayv2 as apigwv2
 from aws_cdk import aws_logs as logs
 from aws_cdk.aws_apigatewayv2_integrations import HttpLambdaIntegration
@@ -43,6 +44,7 @@ class WebsiteStack(Stack):
         repo_root = Path(__file__).resolve().parents[2]
         frontend_dist = str(repo_root / "frontend" / "dist")
         profile_lambda_dir = str(repo_root / "infra" / "lambda" / "profile_api_py")
+        admin_access_lambda_dir = str(repo_root / "infra" / "lambda" / "admin_access_api_py")
 
         # Pull Cognito from UserDataStack
         user_pool = user_data_stack.user_pool
@@ -175,6 +177,80 @@ class WebsiteStack(Stack):
             )
             api_base_url = http_api.api_endpoint
 
+        admin_access_api_base_url = None
+        admin_access_fn = lambda_.Function(
+            self, "AdminAccessApi",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            handler="handler.handler",
+            code=lambda_.Code.from_asset(admin_access_lambda_dir),
+            log_retention=logs.RetentionDays.ONE_DAY,
+            environment={
+                "USER_POOL_ID": user_pool.user_pool_id,
+                "ADMIN_GROUP_NAME": allowed_groups[0],
+                "ANALYST_GROUP_NAME": allowed_groups[1],
+                "VIEWER_GROUP_NAME": allowed_groups[2],
+            },
+        )
+        admin_access_fn.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "cognito-idp:AdminAddUserToGroup",
+                    "cognito-idp:AdminRemoveUserFromGroup",
+                    "cognito-idp:AdminGetUser",
+                    "cognito-idp:AdminListGroupsForUser",
+                    "cognito-idp:ListUsers",
+                ],
+                resources=[user_pool.user_pool_arn],
+            )
+        )
+        admin_access_api = apigwv2.HttpApi(
+            self, "AdminAccessHttpApi",
+            cors_preflight=apigwv2.CorsPreflightOptions(
+                allow_origins=["*"],
+                allow_methods=[
+                    apigwv2.CorsHttpMethod.GET,
+                    apigwv2.CorsHttpMethod.POST,
+                    apigwv2.CorsHttpMethod.OPTIONS,
+                ],
+                allow_headers=["Authorization", "Content-Type"],
+            ),
+            default_authorizer=HttpJwtAuthorizer(
+                "AdminAccessCognitoAuth", issuer,
+                jwt_audience=[web_client_id],
+            ),
+        )
+        admin_access_api.add_routes(
+            path="/admin/access/groups",
+            methods=[apigwv2.HttpMethod.GET],
+            integration=HttpLambdaIntegration("AdminAccessGroupsIntegration", admin_access_fn),
+        )
+        admin_access_api.add_routes(
+            path="/admin/access/whoami",
+            methods=[apigwv2.HttpMethod.GET],
+            integration=HttpLambdaIntegration("AdminAccessWhoamiIntegration", admin_access_fn),
+        )
+        admin_access_api.add_routes(
+            path="/admin/access/users",
+            methods=[apigwv2.HttpMethod.GET],
+            integration=HttpLambdaIntegration("AdminAccessUsersIntegration", admin_access_fn),
+        )
+        admin_access_api.add_routes(
+            path="/admin/access/users/{identifier}",
+            methods=[apigwv2.HttpMethod.GET],
+            integration=HttpLambdaIntegration("AdminAccessUserIntegration", admin_access_fn),
+        )
+        admin_access_api.add_routes(
+            path="/admin/access/grant",
+            methods=[apigwv2.HttpMethod.POST],
+            integration=HttpLambdaIntegration("AdminAccessGrantIntegration", admin_access_fn),
+        )
+        admin_access_api.add_routes(
+            path="/admin/access/revoke",
+            methods=[apigwv2.HttpMethod.POST],
+            integration=HttpLambdaIntegration("AdminAccessRevokeIntegration", admin_access_fn),
+        )
+        admin_access_api_base_url = admin_access_api.api_endpoint
+
         telemetry_api_base_url = None
         if hasattr(backend_stack, "telemetry_api_fn"):
             backend_stack.telemetry_api_fn.add_environment(
@@ -218,6 +294,8 @@ class WebsiteStack(Stack):
 
         if telemetry_api_base_url:
             config["telemetryApiUrl"] = telemetry_api_base_url.rstrip("/")
+        if admin_access_api_base_url:
+            config["adminAccessApiUrl"] = admin_access_api_base_url.rstrip("/")
 
         # ── Deploy frontend ───────────────────────────────────────────────────
         if os.path.isdir(frontend_dist):
@@ -246,3 +324,6 @@ class WebsiteStack(Stack):
         if telemetry_api_base_url:
             CfnOutput(self, "TelemetryApiUrl", value=telemetry_api_base_url,
                       export_name="SentinelNetTelemetryApiUrl")
+        if admin_access_api_base_url:
+            CfnOutput(self, "AdminAccessApiUrl", value=admin_access_api_base_url,
+                      export_name="SentinelNetAdminAccessApiUrl")

--- a/infra/tests/test_admin_access_handler.py
+++ b/infra/tests/test_admin_access_handler.py
@@ -1,0 +1,104 @@
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+class AdminAccessHandlerTests(unittest.TestCase):
+    def setUp(self):
+        os.environ["USER_POOL_ID"] = "pool-123"
+        os.environ["ADMIN_GROUP_NAME"] = "SentinelNetAdmins"
+        os.environ["ANALYST_GROUP_NAME"] = "SentinelNetAnalysts"
+        os.environ["VIEWER_GROUP_NAME"] = "SentinelNetViewers"
+
+        fake_boto3 = types.ModuleType("boto3")
+        fake_boto3.client = MagicMock(return_value=MagicMock())
+        fake_botocore = types.ModuleType("botocore")
+        fake_botocore_exceptions = types.ModuleType("botocore.exceptions")
+
+        class FakeClientError(Exception):
+            def __init__(self, response, operation_name=None):
+                super().__init__(response)
+                self.response = response
+                self.operation_name = operation_name
+
+        fake_botocore_exceptions.ClientError = FakeClientError
+
+        self._previous_boto3 = sys.modules.get("boto3")
+        self._previous_botocore = sys.modules.get("botocore")
+        self._previous_botocore_exceptions = sys.modules.get("botocore.exceptions")
+        sys.modules["boto3"] = fake_boto3
+        sys.modules["botocore"] = fake_botocore
+        sys.modules["botocore.exceptions"] = fake_botocore_exceptions
+        self.addCleanup(self.restore_modules)
+
+        module_name = "admin_access_api_handler_test"
+        module_path = Path(__file__).resolve().parents[1] / "lambda" / "admin_access_api_py" / "handler.py"
+        if module_name in importlib.sys.modules:
+            del importlib.sys.modules[module_name]
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        self.module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(self.module)
+
+    def restore_modules(self):
+        for name, previous in [
+            ("boto3", self._previous_boto3),
+            ("botocore", self._previous_botocore),
+            ("botocore.exceptions", self._previous_botocore_exceptions),
+        ]:
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+    def make_event(self, method="GET", path="/admin/access/groups", groups=None, body=None):
+        claims = {
+            "sub": "admin-1",
+            "email": "admin@example.com",
+            "cognito:username": "admin@example.com",
+        }
+        if groups is not None:
+            claims["cognito:groups"] = groups
+        return {
+            "requestContext": {
+                "http": {"method": method, "path": path},
+                "authorizer": {"jwt": {"claims": claims}},
+            },
+            "rawPath": path,
+            "body": body,
+        }
+
+    def test_requires_authorizer_context(self):
+        response = self.module.handler({"rawPath": "/admin/access/groups", "requestContext": {"http": {"method": "GET"}}}, None)
+        self.assertEqual(response["statusCode"], 401)
+
+    def test_rejects_non_admins(self):
+        response = self.module.handler(self.make_event(groups=["SentinelNetAnalysts"]), None)
+        self.assertEqual(response["statusCode"], 403)
+
+    def test_returns_groups_for_admin(self):
+        response = self.module.handler(self.make_event(groups=["SentinelNetAdmins"]), None)
+        self.assertEqual(response["statusCode"], 200)
+        self.assertIn("SentinelNetAdmins", response["body"])
+
+    def test_rejects_invalid_group_on_grant(self):
+        response = self.module.handler(
+            self.make_event(
+                method="POST",
+                path="/admin/access/grant",
+                groups=["SentinelNetAdmins"],
+                body='{"identifier":"user@example.com","group":"Owners"}',
+            ),
+            None,
+        )
+        self.assertEqual(response["statusCode"], 400)
+        self.assertIn("Invalid group", response["body"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds an admin-only Access Management Terminal to the SentinelNet website as a safe UX layer on top of the existing Cognito group-based ACL system. It introduces a new /admin/access page that is only visible and accessible to users in SentinelNetAdmins