### PR TITLE
Fix TheHive ALB health check path

### DIFF
--- a/infra/stacks/backend_stack.py
+++ b/infra/stacks/backend_stack.py
@@ -395,7 +395,7 @@ class BackendStack(Stack):
             default_action=elbv2.ListenerAction.fixed_response(404, content_type="text/plain", message_body="Not Found")
         )
 
-        thehive_tg = elbv2.ApplicationTargetGroup(self, "TheHiveTG", vpc=vpc, port=9000, protocol=elbv2.ApplicationProtocol.HTTP, targets=[targets.InstanceTarget(self.instance, 9000)], health_check=elbv2.HealthCheck(path="/thehive", interval=Duration.seconds(20), healthy_threshold_count=2, unhealthy_threshold_count=3, healthy_http_codes="200-499"))
+        thehive_tg = elbv2.ApplicationTargetGroup(self, "TheHiveTG", vpc=vpc, port=9000, protocol=elbv2.ApplicationProtocol.HTTP, targets=[targets.InstanceTarget(self.instance, 9000)], health_check=elbv2.HealthCheck(path="/", interval=Duration.seconds(20), healthy_threshold_count=2, unhealthy_threshold_count=3, healthy_http_codes="200-499"))
         grafana_tg = elbv2.ApplicationTargetGroup(self, "GrafanaTG", vpc=vpc, port=3000, protocol=elbv2.ApplicationProtocol.HTTP, targets=[targets.InstanceTarget(self.instance, 3000)], health_check=elbv2.HealthCheck(path="/grafana/login", interval=Duration.seconds(20), healthy_threshold_count=2, unhealthy_threshold_count=3, healthy_http_codes="200-499"))
 
         https_listener.add_action("TheHiveAuth", priority=10, conditions=[elbv2.ListenerCondition.path_patterns(["/thehive", "/thehive/*"])], action=elb_actions.AuthenticateCognitoAction(user_pool=user_pool, user_pool_client=alb_client, user_pool_domain=user_pool_domain, next=elbv2.ListenerAction.forward([thehive_tg])))


### PR DESCRIPTION
Since the ALB health check is internal and should not depend on the public /thehive subpath, I changed only the TheHive target group health check path in backend_stack.py from /thehive to /